### PR TITLE
Fixing Module Styling

### DIFF
--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -439,6 +439,16 @@ div.historyinfo {
   margin: 0px 3px 3px 0px;
   background: #efefef;
   border-radius: 4px;
-  height: 28px;
+  height: 24px;
+}
+
+.selectize-control.single, .selectize-control.multi {
+  height:auto;
+}
+
+.selectize-control.multi .selectize-input:after {
+  content: "\e8ac";
+  font-size: 12px;
+  font-weight: bold;
 }
 


### PR DESCRIPTION
Modifying module boxes to prevent extension below the underline.
Dropdown arrow larger and more visible.
Changing module division to be dynamic depending on number of modules selected.